### PR TITLE
Remove `tendermint_healthcheck` round in check string

### DIFF
--- a/tests/test_packages/test_agents/test_simple_abci.py
+++ b/tests/test_packages/test_agents/test_simple_abci.py
@@ -26,7 +26,7 @@ from tests.test_packages.test_agents.base import BaseTestEnd2EndNormalExecution
 
 # check log messages of the happy path
 CHECK_STRINGS = (
-   "Entered in the 'registration' round for period 0",
+    "Entered in the 'registration' round for period 0",
     "'registration' round is done",
     "Entered in the 'randomness_startup' round for period 0",
     "'randomness_startup' round is done",


### PR DESCRIPTION
This PR resolves the following error from running single agent test, as healthcheck is currently not an individual round.


```
$ pytest tests/test_packages/test_agents/test_simple_abci.py::TestSimpleABCISingleAgent

---------------------------------------------------------------------------- Captured log call ----------------------------------------------------------------------------
DEBUG    root:base.py:141 Launching agent agent_00000...
INFO     root:base.py:155 Waiting Tendermint nodes to be up
DEBUG    urllib3.connectionpool:connectionpool.py:228 Starting new HTTP connection (1): localhost:26657
DEBUG    root:base.py:59 Health-check attempt 0 for http://localhost:26657 failed. Retrying in 3.0 seconds...
DEBUG    urllib3.connectionpool:connectionpool.py:228 Starting new HTTP connection (1): localhost:26657
DEBUG    urllib3.connectionpool:connectionpool.py:456 http://localhost:26657 "GET /health HTTP/1.1" 200 50
========================================================================= short test summary info =========================================================================
FAILED tests/test_packages/test_agents/test_simple_abci.py::TestSimpleABCISingleAgent::test_run - AssertionError: Strings ["Entered in the 'tendermint_healthcheck' behaviour state"] didn't appear in agent output.
====================================================================== 1 failed in 62.06s (0:01:02) =======================================================================

```