### PR TITLE
fix: remove `arbitrum` from harvest job

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -13,7 +13,7 @@
         "contract/valory/keep3r_my_job/0.1.0": "bafybeicgw4mudefo3opa4udbw67qznfkqoewifg3dc2rwtayef7ctwakbq",
         "service/valory/keep3r_bot/0.1.0": "bafybeidn3pgtofyom7mwusjm73ydy2librqcofrxwqhxajyh2rrdvlyngy",
         "service/valory/keep3r_bot_goerli/0.1.0": "bafybeigiexj6ss462scb35oasmwl44ckuoynyqjfu3nrh4smg74zo7cfxe",
-        "contract/valory/yearn_factory_harvest_job/0.1.0": "bafybeiarfp4m4id77tsbpprcmcm5nv6ihwkeenrgrb6kth47uvkqhmh5za",
+        "contract/valory/yearn_factory_harvest_job/0.1.0": "bafybeiflgl2yyu5wl5a2pogs6tnp2zwxwd252v67ysjn4ukfwj6htxw4xa",
         "protocol/valory/ledger_api/1.0.0": "bafybeieylbg4qb3dmjlm3zufqcwq4qbygsdgj3jzc53eyoqmd25mdz2pkq",
         "connection/valory/ledger/0.19.0": "bafybeih4yf73bwvn3cn44b7on2riqe2lbvixcgw3nze63asvwbmyfqyrc4",
         "skill/valory/abstract_round_abci/0.1.0": "bafybeiao4oawiwnqwfkeacfojwbwzqiwdmbqyq4xtwu26p66mss4db343e",

--- a/packages/valory/contracts/yearn_factory_harvest_job/contract.py
+++ b/packages/valory/contracts/yearn_factory_harvest_job/contract.py
@@ -93,7 +93,7 @@ class YearnFactoryHarvestJobContract(Contract):
         :param kwargs: other keyword arguments
         :return: the off chain data
         """
-        return dict(chain_id="arbitrum")
+        return dict()
 
     @classmethod
     def workable(

--- a/packages/valory/contracts/yearn_factory_harvest_job/contract.yaml
+++ b/packages/valory/contracts/yearn_factory_harvest_job/contract.yaml
@@ -8,8 +8,8 @@ aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   YearnFactoryHarvestJob.json: bafybeihgjjq6ttbccz3utl23gdvyige6bcdwwvi5wo2tuu3qv4wqxr4qra
   __init__.py: bafybeiflwdigkqjdp33usxkaozixd5cwyq35jy6eyf2lcr2gtp5kjbs6re
-  contract.py: bafybeiazxzufydrzph4at5mqqg2bh4hoxikocp7fhm7rxn4kog2urcldfm
-  test_contract.py: bafybeihue7ijmrxyxhq3wkch5cxrwwhn6kwo47avelyrzld345fws6ntfm
+  contract.py: bafybeieqlouh6hmcej3w3pvfpaijxhuilbcmk6s657jydbqrfccnxjm4bu
+  test_contract.py: bafybeihgfcsuvickfcek3oordz2wxpyujkywev7efr5bacwh7vylmwpu4a
 fingerprint_ignore_patterns: []
 contracts: []
 class_name: YearnFactoryHarvestJobContract

--- a/packages/valory/contracts/yearn_factory_harvest_job/test_contract.py
+++ b/packages/valory/contracts/yearn_factory_harvest_job/test_contract.py
@@ -84,10 +84,16 @@ class TestYearnFactoryHarvestJobContract(BaseContractTestCase):
         dummy_keep3r = self.contract_address
 
         contract = cast(YearnFactoryHarvestJobContract, self.contract)
+        off_chain_data = contract.get_off_chain_data(
+            self.ledger_api,
+            self.contract_address,
+        )
+        assert off_chain_data == dict()
         workable = contract.workable(
             self.ledger_api,
             self.contract_address,
             keep3r_address=dummy_keep3r,
+            **off_chain_data,
         )
         assert workable.get("data", False)
 
@@ -96,6 +102,7 @@ class TestYearnFactoryHarvestJobContract(BaseContractTestCase):
             self.ledger_api,
             self.contract_address,
             keep3r_address=dummy_keep3r,
+            **off_chain_data,
         )
         assert work_tx.get("data", False)
 


### PR DESCRIPTION
This PR removes the chain ID from the yearn job contract. 