### PR TITLE
chore: update-history [no ci]

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # Release History - `agent-academy-2`
 
+## v0.3.0 (12.04.2023)
+- Added `manual_gas_limit`.
+- Added 4-agent support.
+- Added quicker tolerance finalization failure. 
+- Added check for all supported contracts in a single `IsWorkable` round.
+
 ## v0.2.1 (03.04.2023)
 - Add service termination.
 - Add mint data for the components from the autonolas on-chain protocol.


### PR DESCRIPTION
This PR adds `v0.3.0` to release history.  